### PR TITLE
docs: Atualizar o arquivo README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ O GitLab traz ferramentas de CI/CD que simplificam esses processos, ajudando as 
 
 `feat: adicionado novo arquivo`
 
-#### Treine seus commits no Free Explorer
+#### Treine seus commits
+- [Convenção](https://www.conventionalcommits.org/)
 - [FreeExplorer](https://git-school.github.io/visualizing-git/)
 <br>
 


### PR DESCRIPTION
Este commit adiciona a URL do site "Conventional Commits" para ajudar a novos usuários do Git / GitLab